### PR TITLE
feat: Add chai tool for no-code chat agents

### DIFF
--- a/data/implementacao/delivery.data.ts
+++ b/data/implementacao/delivery.data.ts
@@ -109,6 +109,7 @@ export const deliveryTrackData = {
               { name: "promptlayer (prompt + nós de automação)" , url: "https://www.promptlayer.com/" },
               { name: "workflowai (estilo chat e prompt)", url: "https://workflowai.com/" },
               { name: "rowboatlabs (estilo chat)", url: "https://rowboatlabs.com/" },
+              { name: "chai (estilo chat)", url: "https://chai.new/" },
               { name: "wordware.ai (estilo doc)", url: "https://app.wordware.ai/lp" },
               { name: "dify.ai (nós de automação)", url: "https://dify.ai" },
               { name: "n8n (nós de automação)", url: "https://n8n.io/ " },

--- a/data/implementacao/discovery.data.ts
+++ b/data/implementacao/discovery.data.ts
@@ -120,6 +120,7 @@ export const discoveryTrackData = {
               { name: "promptlayer (prompt + nós de automação)", url: "https://www.promptlayer.com/" },
               { name: "workflowai (estilo chat e prompt)", url: "https://workflowai.com/" },
               { name: "rowboatlabs (estilo chat)", url: "https://rowboatlabs.com/" },
+              { name: "chai (estilo chat)", url: "https://chai.new/" },
               { name: "wordware.ai (estilo doc)", url: "https://app.wordware.ai/lp" },
               { name: "dify.ai (nós de automação)", url: "https://dify.ai" },
               { name: "n8n (nós de automação)", url: "https://n8n.io/ " },


### PR DESCRIPTION
Adds the 'chai' tool (https://chai.new) to the list of tools for creating no-code AI agents with a chat style.

The tool has been added to the following files:
- data/implementacao/delivery.data.ts
- data/implementacao/discovery.data.ts