### PR TITLE
Fix: Update incorrect URL for 'explorar alternativas de interfaces e …

### DIFF
--- a/data/definicao/2-proposta-inicial.data.ts
+++ b/data/definicao/2-proposta-inicial.data.ts
@@ -90,7 +90,7 @@ export const propostaInicialStages = [
           items: [
             {
               name: "explorar alternativas de interfaces e interação",
-              url: "https://calirenato82.substack.com/p/prompt-ia-avaliacao-da-proposta-de-solucao",
+              url: "https://calirenato82.substack.com/p/prompt-ia-alternativas-interfaces",
             },
             {
               name: "definição de fluxos e affordances",


### PR DESCRIPTION
…interação'

This commit corrects the URL associated with the 'explorar alternativas de interfaces e interação' resource within the 'interfaces alternativas' stage in the `data/definicao/2-proposta-inicial.data.ts` file.

The previous URL was `https://calirenato82.substack.com/p/prompt-ia-avaliacao-da-proposta-de-solucao`, and it has been updated to the correct link: `https://calirenato82.substack.com/p/prompt-ia-alternativas-interfaces`.