### PR TITLE
Reorder DeepWiki link in two files

### DIFF
--- a/data/definicao/3-riscos-refinamento.data.ts
+++ b/data/definicao/3-riscos-refinamento.data.ts
@@ -21,9 +21,9 @@ export const riscosRefinamentoStages = [
           items: [
               { name: "context7 (carregar docs de libs para llm)", url: "https://context7.com/" },
               { name: "gitmcp (transforma um repositório em um mcp server pra consulta)", url: "https://gitmcp.io/" },
+              { name: "DeepWiki", url: "http://deepwiki.com/" },
               { name: "Tutorial-Codebase-Knowledge", url: "https://github.com/The-Pocket/Tutorial-Codebase-Knowledge" },
               { name: "DeepWiki Open (versão open-source)", url: "https://github.com/AsyncFuncAI/deepwiki-open" },
-              { name: "DeepWiki", url: "http://deepwiki.com/" },
               { name: "CodeGraph", url: "https://github.com/ChrisRoyse/CodeGraph" },
               { name: "probe ai", url: "https://probeai.dev/" },
               { name: "readme-ai", url: "https://github.com/eli64s/readme-ai" },

--- a/data/definicao/3-riscos-refinamento.data.ts
+++ b/data/definicao/3-riscos-refinamento.data.ts
@@ -21,7 +21,7 @@ export const riscosRefinamentoStages = [
           items: [
               { name: "context7 (carregar docs de libs para llm)", url: "https://context7.com/" },
               { name: "gitmcp (transforma um repositório em um mcp server pra consulta)", url: "https://gitmcp.io/" },
-              { name: "DeepWiki", url: "http://deepwiki.com/" },
+              { name: "DeepWiki", url: "https://deepwiki.com/" },
               { name: "Tutorial-Codebase-Knowledge", url: "https://github.com/The-Pocket/Tutorial-Codebase-Knowledge" },
               { name: "DeepWiki Open (versão open-source)", url: "https://github.com/AsyncFuncAI/deepwiki-open" },
               { name: "CodeGraph", url: "https://github.com/ChrisRoyse/CodeGraph" },

--- a/data/implementacao/delivery.data.ts
+++ b/data/implementacao/delivery.data.ts
@@ -22,12 +22,12 @@ export const deliveryTrackData = {
           {
             title: "ferramentas ia para entender melhor o código - via documentação, mcp server ou outras formas",
             items: [
+              { name: "DeepWiki", url: "http://deepwiki.com/" },
               { name: "code2tutorial", url: "https://code2tutorial.com/" },
               { name: "DeepWiki Open (versão open-source)", url: "https://github.com/AsyncFuncAI/deepwiki-open" },
               { name: "probe ai", url: "https://probeai.dev/" },
               { name: "gitmcp (transforma um repositório em um mcp server pra consulta)", url: "https://gitmcp.io/" },
               { name: "context7 (carregar docs de libs para llm)", url: "https://context7.com/" },
-              { name: "DeepWiki", url: "http://deepwiki.com/" },
               { name: "CodeAlive", url: "https://www.codealive.ai/" },
               {
                 name: "serena (análise semântica para qualquer agente ia ou integração claude desktop)",


### PR DESCRIPTION
This commit reorders the DeepWiki link in two files:

- In `data/definicao/3-riscos-refinamento.data.ts`, the DeepWiki link was moved to the third position in the list under "mapear riscos técnicos de desenvolvimento".
- In `data/implementacao/delivery.data.ts`, the DeepWiki link was moved to the first position in the list under "desenvolvimento com integração contínua".