### PR TITLE
Fix: Atualiza link do Minimax para URL correta

### DIFF
--- a/data/definicao/4-prototipacao-decisao.data.ts
+++ b/data/definicao/4-prototipacao-decisao.data.ts
@@ -85,7 +85,7 @@ export const prototipacaoDecisaoStages = [
         {
           "title": "ferramentas ia de navegação autônoma",
           "items": [
-            { "name": "minimax", "url": "https://chat.minimax.io/" },
+            { "name": "minimax", "url": "https://agent.minimax.io/" },
             { "name": "scout new", "url": "https://scout.new/" },
             { "name": "kortix suna", "url": "https://www.suna.so/" },
             { "name": "skywork", "url": "https://skywork.ai/" },


### PR DESCRIPTION
O link para o Minimax em data/definicao/4-prototipacao-decisao.data.ts estava apontando para https://chat.minimax.io/ e foi corrigido para https://agent.minimax.io/.