### PR TITLE
Add Reforge Concept Testing to relevant stages

### DIFF
--- a/data/compreensao/3-analise-qualitativa.data.ts
+++ b/data/compreensao/3-analise-qualitativa.data.ts
@@ -11,13 +11,14 @@ export const analiseQualitativaData = {
       {
         title: "ferramentas ia específicas para encontrar padrões e insights de entrevistas",
         items: [
+          { name: "condens", url: "https://condens.io/" },
           { name: "delve", url: "https://delvetool.com/" },
           { name: "dovetail", url: "https://dovetail.com/" },
-          { name: "marvin", url: "https://heymarvin.com/" },
-          { name: "condens", url: "https://condens.io/" },
-          { name: "reduct", url: "https://reduct.video/" },
-          { name: "looppanel", url: "https://www.looppanel.com/" },
           { name: "insightlab", url: "https://www.getinsightlab.com/" },
+          { name: "looppanel", url: "https://www.looppanel.com/" },
+          { name: "marvin", url: "https://heymarvin.com/" },
+          { name: "reduct", url: "https://reduct.video/" },
+          { name: "reforge concept testing", url: "https://www.reforge.com/blog/concept-testing" },
         ],
       },
       {

--- a/data/definicao/1-delimitacao-ideacao.data.ts
+++ b/data/definicao/1-delimitacao-ideacao.data.ts
@@ -74,6 +74,17 @@ export const delimitacaoIdeacaoStages = [
     responsibles: ["humano"],
     details: {
       comment: "escolher ideia mais promissora para o apetite",
+      resources: [
+        {
+          title: "ferramentas para validação de conceito",
+          items: [
+            {
+              name: "reforge concept testing",
+              url: "https://www.reforge.com/blog/concept-testing",
+            },
+          ],
+        },
+      ],
     },
   },
 ]

--- a/data/definicao/2-proposta-inicial.data.ts
+++ b/data/definicao/2-proposta-inicial.data.ts
@@ -7,6 +7,17 @@ export const propostaInicialStages = [
     responsibles: ["humano"],
     details: {
       comment: "elaborar um esboço sumarizado da proposta inicial",
+      resources: [
+        {
+          title: "ferramentas para validação de conceito",
+          items: [
+            {
+              name: "reforge concept testing",
+              url: "https://www.reforge.com/blog/concept-testing",
+            },
+          ],
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Added "Reforge Concept Testing" tool to "Análise Qualitativa" (Stage 3), "Selecionar Ideia" (Stage 15), and "Definir Proposta Inicial" (Stage 16). The tool is categorized under concept validation and interview insights. Also sorted the tool list in `3-analise-qualitativa.data.ts`.

---
*PR created automatically by Jules for task [4608645359131503334](https://jules.google.com/task/4608645359131503334) started by @renatocaliari*