### PR TITLE
Adicionar zvec à lista de bancos de dados vetoriais

### DIFF
--- a/data/implementacao/delivery.data.ts
+++ b/data/implementacao/delivery.data.ts
@@ -179,6 +179,7 @@ export const deliveryTrackData = {
               { name: "trychroma", url: "https://www.trychroma.com/" },
               { name: "weaviate", url: "https://weaviate.io/" },
               { name: "zep", url: "https://www.getzep.com/" },
+              { name: "zvec (in-process vector database)", url: "https://github.com/alibaba/zvec" },
             ],
           },
           {


### PR DESCRIPTION
Este PR adiciona o repositório zvec da Alibaba à lista de ferramentas de banco de dados e RAG no arquivo de dados de entrega (delivery). O zvec foi identificado como um banco de dados vetorial in-process leve e de alta performance, encaixando-se perfeitamente na trilha de implementação.

Mudanças:
- Inclusão de `{ name: "zvec (in-process vector database)", url: "https://github.com/alibaba/zvec" }` em `data/implementacao/delivery.data.ts`.
- Verificação visual realizada para garantir que o item aparece corretamente na interface.

---
*PR created automatically by Jules for task [8530655740793167807](https://jules.google.com/task/8530655740793167807) started by @renatocaliari*