### PR TITLE
Add deerflow (open-source) to appropriate tool lists

### DIFF
--- a/data/compreensao/1-mapeamento-inicial.data.ts
+++ b/data/compreensao/1-mapeamento-inicial.data.ts
@@ -49,6 +49,7 @@ export const mapeamentoInicialData = {
           { "name": "browser use", "url": "https://browser-use.com/" },
           { "name": "capy.ai", "url": "https://capy.ai/" },
           { "name": "claude computer", "url": "https://docs.anthropic.com/en/docs/agents-and-tools/computer-use" },
+          { "name": "deerflow (open-source)", "url": "https://deerflow.tech/" },
           { "name": "dobrowser", "url": "https://www.dobrowser.io/" },
           { "name": "dojoma", "url": "https://dojoma.ai/" },
           { "name": "flowithio", "url": "https://flowith.io/" },

--- a/data/compreensao/4-analise-tendencias.data.ts
+++ b/data/compreensao/4-analise-tendencias.data.ts
@@ -39,6 +39,7 @@ export const analiseTendenciasData = {
           { "name": "browser use", "url": "https://browser-use.com/" },
           { "name": "capy.ai", "url": "https://capy.ai/" },
           { "name": "claude computer", "url": "https://docs.anthropic.com/en/docs/agents-and-tools/computer-use" },
+          { "name": "deerflow (open-source)", "url": "https://deerflow.tech/" },
           { "name": "dobrowser", "url": "https://www.dobrowser.io/" },
           { "name": "dojoma", "url": "https://dojoma.ai/" },
           { "name": "flowithio", "url": "https://flowith.io/" },


### PR DESCRIPTION
Added `deerflow (open-source)` to the "Ferramentas de Exploração Semi-Autônoma" category in the following data files:
- `data/compreensao/1-mapeamento-inicial.data.ts`
- `data/compreensao/4-analise-tendencias.data.ts`

This tool was added because it is a relevant alternative in the same category as "manus". The additions maintain alphabetical order within their respective lists.

Verified the changes via Playwright screenshots, confirming visibility in:
1. The "General AI Tools" footer section.
2. The "mapeamento inicial" accordion under "mapeamento de oportunidades".

Cleaned up all temporary verification artifacts and logs before submission.

---
*PR created automatically by Jules for task [10530182127165520446](https://jules.google.com/task/10530182127165520446) started by @renatocaliari*